### PR TITLE
Fix manpage (.EL is not a known macro and imho not needed)

### DIFF
--- a/src/util/edac-ctl.8.in
+++ b/src/util/edac-ctl.8.in
@@ -103,7 +103,6 @@ to read DMI information from the sysfs files
 If the sysfs files above do not exist, then \fBedac-ctl\fR will fall
 back to parsing output of the \fBdmidecode\fR(8) utility. Use of this
 utility will most often require that \fBedac-ctl\fR be run as root.
-.EL
 
 .SH SEE ALSO
 \fBedac\fR(3), \fBedac-util\fR(1)


### PR DESCRIPTION
I could be wrong ;)  but that is how man complaints now, see for yourself with

 LC_ALL=en_US.UTF-8 MANWIDTH=80 man --warnings -E UTF-8 -l ./src/util/edac-ctl.8.in >/dev/null
