### PR TITLE
Update COPYING with the latest GPLv2 text; update GPLv2 notices

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
                        Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -304,8 +304,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -329,8 +328,8 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may

--- a/config/config.guess
+++ b/config/config.guess
@@ -16,9 +16,7 @@ timestamp='2004-09-07'
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-# 02110-1301, USA.
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
 #
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a

--- a/config/config.sub
+++ b/config/config.sub
@@ -20,9 +20,7 @@ timestamp='2004-08-29'
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-# 02110-1301, USA.
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a

--- a/config/depcomp
+++ b/config/depcomp
@@ -16,9 +16,7 @@ scriptversion=2004-05-31.23
 # GNU General Public License for more details.
 
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-# 02110-1301, USA.
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a

--- a/config/ltmain.sh
+++ b/config/ltmain.sh
@@ -16,9 +16,7 @@
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-# 02110-1301, USA.
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
 #
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a

--- a/config/missing
+++ b/config/missing
@@ -18,9 +18,7 @@ scriptversion=2004-09-07.08
 # GNU General Public License for more details.
 
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-# 02110-1301, USA.
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a

--- a/configure
+++ b/configure
@@ -9709,8 +9709,7 @@ echo "$as_me: creating $ofile" >&6;}
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
 #
 # As a special exception to the GNU General Public License, if you
 # distribute this file as part of a program that contains a

--- a/configure.ac
+++ b/configure.ac
@@ -21,8 +21,7 @@
 ## for more details.
 ##
 ## You should have received a copy of the GNU General Public License along
-## with this program; if not, write to the Free Software Foundation, Inc.,
-## 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+## with this program; if not, see <https://www.gnu.org/licenses/>.
 ##*****************************************************************************
 
 AC_INIT

--- a/src/lib/edac.3.in
+++ b/src/lib/edac.3.in
@@ -19,8 +19,7 @@
 .\" for more details.
 .\"
 .\" You should have received a copy of the GNU General Public License along
-.\" with this program; if not, write to the Free Software Foundation, Inc.,
-.\" 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+.\" with this program; if not, see <https://www.gnu.org/licenses/>.
 .\"****************************************************************************
 
 .TH EDAC 3 "@META_DATE@" "@META_ALIAS" "EDAC error reporting library"

--- a/src/lib/edac.h
+++ b/src/lib/edac.h
@@ -19,8 +19,7 @@
  *  for more details.
  *
  *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *  with this program; if not, see <https://www.gnu.org/licenses/>.
  *****************************************************************************/
 #ifndef _LIBEDAC_H
 #define _LIBEDAC_H

--- a/src/lib/libedac.c
+++ b/src/lib/libedac.c
@@ -19,8 +19,7 @@
  *  for more details.
  *
  *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *  with this program; if not, see <https://www.gnu.org/licenses/>.
  *****************************************************************************/
 
 #if HAVE_CONFIG_H

--- a/src/util/edac-ctl.8.in
+++ b/src/util/edac-ctl.8.in
@@ -19,8 +19,7 @@
 .\" for more details.
 .\"
 .\" You should have received a copy of the GNU General Public License along
-.\" with this program; if not, write to the Free Software Foundation, Inc.,
-.\" 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+.\" with this program; if not, see <https://www.gnu.org/licenses/>.
 .\"****************************************************************************
 
 .TH EDAC-CTL 8 "@META_DATE@" "@META_ALIAS@" "EDAC admin utility"

--- a/src/util/edac-ctl.in
+++ b/src/util/edac-ctl.in
@@ -20,8 +20,7 @@
 #  for more details.
 #
 #  You should have received a copy of the GNU General Public License along
-#  with this program; if not, write to the Free Software Foundation, Inc.,
-#  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+#  with this program; if not, see <https://www.gnu.org/licenses/>.
 #****************************************************************************/
 
 use strict;

--- a/src/util/edac-util.1.in
+++ b/src/util/edac-util.1.in
@@ -19,8 +19,7 @@
 .\" for more details.
 .\"
 .\" You should have received a copy of the GNU General Public License along
-.\" with this program; if not, write to the Free Software Foundation, Inc.,
-.\" 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+.\" with this program; if not, see <https://www.gnu.org/licenses/>.
 .\"****************************************************************************
 
 .TH EDAC-UTIL 1 "@META_DATE@" "@META_ALIAS@" "EDAC error reporting utility"

--- a/src/util/edac-util.c
+++ b/src/util/edac-util.c
@@ -19,8 +19,7 @@
  *  for more details.
  *
  *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+ *  with this program; if not, see <https://www.gnu.org/licenses/>.
  *****************************************************************************/
 
 #if HAVE_CONFIG_H

--- a/src/util/list.c
+++ b/src/util/list.c
@@ -19,8 +19,7 @@
  *  more details.
  *
  *  You should have received a copy of the GNU General Public License along
- *  with LSD-Tools; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *  with LSD-Tools; if not, see <https://www.gnu.org/licenses/>.
  *****************************************************************************
  *  Refer to "list.h" for documentation on public functions.
  *****************************************************************************

--- a/src/util/list.h
+++ b/src/util/list.h
@@ -18,8 +18,7 @@
  *  more details.
  *
  *  You should have received a copy of the GNU General Public License along
- *  with LSD-Tools; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *  with LSD-Tools; if not, see <https://www.gnu.org/licenses/>.
  *****************************************************************************
  *  This file is originally  from LSD-Tools, the LLNL Software 
  *  Development Toolbox.

--- a/src/util/split.c
+++ b/src/util/split.c
@@ -19,8 +19,7 @@
  *  details.
  *  
  *  You should have received a copy of the GNU General Public License along
- *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *  with Pdsh; if not, see <https://www.gnu.org/licenses/>.
 \*****************************************************************************/
 
 #include <string.h>

--- a/src/util/split.h
+++ b/src/util/split.h
@@ -19,8 +19,7 @@
  *  details.
  *  
  *  You should have received a copy of the GNU General Public License along
- *  with Pdsh; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *  with Pdsh; if not, see <https://www.gnu.org/licenses/>.
 \*****************************************************************************/
 #ifndef _SPLIT_H
 #define _SPLIT_H


### PR DESCRIPTION
Text from https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt; for notices, see also https://www.gnu.org/licenses/old-licenses/gpl-2.0.html#SEC4.

There is no more postal address since the FSF is now remote-only; a placeholder name was changed in the GPLv2 text.